### PR TITLE
Add a third assignment to test Kubernetes knowledge

### DIFF
--- a/sre-instrumentation-challenge/README.md
+++ b/sre-instrumentation-challenge/README.md
@@ -6,14 +6,14 @@ Your goal is to add Prometheus instrumentation to our in-memory Storage API whic
 
 ## Your mission, should you choose to accept it:
 
-### Step 1
+### Step 1: Implementation
 
 - Add the Prometheus metrics endpoint to the Storage API
 - Expose HTTP request duration in seconds by path, method and status code
 - Create a Dockerfile for the Storage API. The Prometheus Server expects it to run on `http://storage_api:5000`.
 - Add the newly dockerized Storage API to our docker-compose setup
 
-### Step 2
+### Step 2: Visualization
 
 1. Run `docker-compose up`
 2. Create a new Grafana dashboard here: http://localhost:3000
@@ -29,6 +29,16 @@ It should look something like this:
 Tip: Run `scripts/generate_traffic.sh` to generate some traffic to the Storage API . The script expects the Storage API to run on http://localhost:5000.
 
 4. Try to figure out why you see HTTP 500 errors for some endpoints
+
+### Step 3: Deployment
+
+In the last step we want to run the setup we have from our `docker-compose.yml` file on Kubernetes. Please create the Kubernetes resources for
+
+- Storage API application
+- Prometheus
+- Grafana
+
+How you create or generate the resource files (YAML files) is up to you. Depending on the time left, it is fine to take shortcuts or only creating the resource files without actually applying them to a Kubernetes cluster. Also don't invest much time into the volume setup.
 
 ## Evaluation criteria
 


### PR DESCRIPTION
When doing the interviews for Grid I realised that our challenge is quite good to assess the candidate's coding abilities and a bit weak on the operations side.
Therefore I added a 3rd assignment where the candidates need to create the Kubernetes manifests. The goal is primary to see if candidates understand what resources they need (Deployments, Services, maybe ingress) and not about the correctness as this might take too much time. I'm not sure if candidates understand that it is okay to be more on the theoretical side. What do you think?